### PR TITLE
update PS1 foreground color

### DIFF
--- a/dotfiles/bashrc
+++ b/dotfiles/bashrc
@@ -14,7 +14,7 @@ HISTFILESIZE=2000
 shopt -s checkwinsize
 
 # If set, the pattern "**" used in a pathname expansion context will
-PS1='\[\033[1;36m\]$(printf "\\u2500%.0s" $(seq 22 $(tput cols))) \d, \t\n\u@$DUCK@\h : \[\033[1;33m\]\w \n\[\033[1;36m\] >>\[\033[1;37m\] '
+PS1='\[\033[1;36m\]$(printf "\\u2500%.0s" $(seq 22 $(tput cols))) \d, \t\n\u@$DUCK@\h : \[\033[1;33m\]\w \n\[\033[1;36m\] >>\[\033[1;39m\] '
 PROMPT_COMMAND='echo -en "\033]0;$USER@$HOSTNAME\a"'
 PROMPT_DIRTRIM=8
 


### PR DESCRIPTION
Ich wuerde vorschlagen es auf 39 zu stellen, da dies die standard farbe des terminals ist.
das Problem ist, wenn man einen hellen Hintergrund hat, sieht man die Schrift sonst nicht!


https://misc.flogisoft.com/bash/tip_colors_and_formatting

39	Default foreground color
37	Light gray